### PR TITLE
Use dbus-send to query for remaining time for non-OSX

### DIFF
--- a/scripts/battery_remain.sh
+++ b/scripts/battery_remain.sh
@@ -8,8 +8,7 @@ print_battery_remain() {
 	if command_exists "pmset"; then
 		pmset -g batt | awk 'NR==2 { gsub(/;/,""); print $4 }'
 	elif command_exists "upower"; then
-		battery=$(upower -e | grep battery | head -1)
-		upower -i $battery | grep remain | awk '{print $4}'
+		format_time $(average $(upower_time_to_empty; upower_time_to_full))
 	fi
 }
 

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -17,3 +17,47 @@ command_exists() {
 	local command="$1"
 	type "$command" >/dev/null 2>&1
 }
+
+format_time() {
+	seconds=$1
+	((h=${seconds}/3600))
+	((m=(${seconds}%3600)/60))
+	((s=${seconds}%60))
+	printf "%02d:%02d\n" $h $m
+}
+
+# Takes integers separated by newlines and outputs the sum
+average() {
+	sum=0
+	number_of_values=0
+	for value in $@; do
+		if (($value > 0)); then
+			((sum=$sum+$value))
+			((number_of_values=$number_of_values+1))
+		fi
+	done
+	((sum=$sum/$number_of_values))
+	echo $sum
+}
+
+# http://upower.freedesktop.org/docs/Device.html
+dbus_value() {
+	battery=$1
+	value=$2
+	dbus-send --print-reply=literal --system \
+		--dest=org.freedesktop.UPower $battery \
+		org.freedesktop.DBus.Properties.Get string:org.freedesktop.UPower \
+		$value
+}
+
+upower_time_to_empty() {
+	for battery in $(upower -e | grep battery); do
+		dbus_value $battery string:TimeToEmpty | awk '{print $3}'
+	done
+}
+
+upower_time_to_full() {
+	for battery in $(upower -e | grep battery); do
+		dbus_value $battery string:TimeToFull | awk '{print $3}'
+	done
+}

--- a/tests/helpers/assert.sh
+++ b/tests/helpers/assert.sh
@@ -1,0 +1,9 @@
+assert_equal() {
+    expected=$1
+    actual=$2
+
+    if [[ "${expected}" != "${actual}" ]]; then
+        echo "Expected \"${expected}\" but was \"${actual}\""
+        return 1
+    fi
+}

--- a/tests/helpers/test_runner.sh
+++ b/tests/helpers/test_runner.sh
@@ -1,0 +1,14 @@
+run_tests() {
+    for test in $@; do
+        output=$("$test")
+        if [[ $? -eq 0 ]]; then
+            printf "."
+        else
+            echo
+            printf "Error in \"%s\": %s\n" "$test" "$output"
+            exit 1
+        fi
+    done
+    echo
+    echo "All good :)"
+}

--- a/tests/helpers_test
+++ b/tests/helpers_test
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+source `dirname $0`/helpers/assert.sh
+source `dirname $0`/helpers/test_runner.sh
+
+# --- format_time ---
+
+test_format_time_no_seconds() {
+	actual=$(format_time 23)
+	assert_equal "00:00" "${actual}"
+}
+
+test_format_time_minutes() {
+	actual=$(format_time 61)
+	assert_equal "00:01" "${actual}"
+}
+
+test_format_time_minutes_double_digit() {
+	actual=$(format_time 1260)
+	assert_equal "00:21" "${actual}"
+}
+
+test_format_time_hours_and_minutes() {
+	actual=$(format_time 3900)
+	assert_equal "01:05" "${actual}"
+}
+
+# --- average ----
+
+test_average_one_value() {
+	actual=$(average 100)
+	assert_equal "100" "${actual}"
+}
+
+test_average_three_values() {
+	input=$(printf "23\n52\n24\n")
+	actual=$(average $input)
+	assert_equal "33" "${actual}"
+}
+
+test_average_odd_average_is_even() {
+	input=$(printf "3\n2\n")
+	actual=$(average $input)
+	assert_equal "2" "${actual}"
+}
+
+test_average_filters_out_zeros() {
+	input=$(printf "3\n0\n3\n")
+	actual=$(average $input)
+	assert_equal "3" "${actual}"
+}
+
+source `dirname $0`/../scripts/helpers.sh
+
+run_tests \
+	test_format_time_no_seconds \
+	test_format_time_minutes \
+	test_format_time_minutes_double_digit \
+	test_format_time_hours_and_minutes \
+	\
+	test_average_one_value \
+	test_average_three_values \
+	test_average_odd_average_is_even \
+	test_average_filters_out_zeros

--- a/tests/upower_test
+++ b/tests/upower_test
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+source `dirname $0`/helpers/assert.sh
+source `dirname $0`/helpers/test_runner.sh
+
+upower_mock_one_battery() {
+	echo '/org/freedesktop/UPower/devices/line_power_AC'
+	echo '/org/freedesktop/UPower/devices/battery_BAT0'
+}
+
+upower_mock_two_batteries() {
+	echo '/org/freedesktop/UPower/devices/line_power_AC'
+	echo '/org/freedesktop/UPower/devices/battery_BAT0'
+	echo '/org/freedesktop/UPower/devices/battery_BAT1'
+}
+
+dbus_time_mock() {
+	time=0
+	for part in $@; do
+		if [[ "${part}" = "/org/freedesktop/UPower/devices/battery_BAT0" ]]; then
+			time=234
+		elif [[ "${part}" = "/org/freedesktop/UPower/devices/battery_BAT1" ]]; then
+			time=1232
+		fi
+	done
+
+	if [[ "${remaining}" = 0 ]]; then
+		echo "Wrong dbus-send mock invocation"
+		return 1
+	fi
+
+	echo "   variant       int64 ${time}"
+}
+
+dbus_percentage_mock() {
+	percentage=0
+	for part in $@; do
+		if [[ "${part}" = "/org/freedesktop/UPower/devices/battery_BAT0" ]]; then
+			percentage=89
+		elif [[ "${part}" = "/org/freedesktop/UPower/devices/battery_BAT1" ]]; then
+			percentage=99
+		fi
+	done
+
+	if [[ "${remaining}" = 0 ]]; then
+		echo "Wrong dbus-send mock invocation"
+		return 1
+	fi
+
+	echo "   variant       double ${percentage}"
+}
+
+test_upower_time_to_empty_returns_times_of_all_batteries() {
+	upower() {
+		upower_mock_two_batteries $@
+	}
+	dbus-send() {
+		dbus_time_mock $@
+	}
+	actual=$(upower_time_to_empty)
+	expected=$(printf "234\n1232")
+	assert_equal "${expected}" "${actual}"
+}
+
+test_upower_time_to_empty_works_with_one_battery() {
+	upower() {
+		upower_mock_one_battery $@
+	}
+	dbus-send() {
+		dbus_time_mock $@
+	}
+	actual=$(upower_time_to_empty)
+	assert_equal "234" "${actual}"
+}
+
+source `dirname $0`/../scripts/helpers.sh
+
+run_tests \
+	test_upower_time_to_empty_returns_times_of_all_batteries \
+	test_upower_time_to_empty_works_with_one_battery


### PR DESCRIPTION
This is the result of a discussion in tmux-plugins/tmux-battery#6

Unfortunately `upower` does not return the remaining time in seconds and
instead uses formatted strings like "42 minutes". This makes it hard to
add the time of many batteries together. Fortunately UPower also
provides a dbus device that can be queried using dbus-send.

I had to write some helper functions to make this work. This increased
the complexity compared to the previous solution. That's why I decided
to also write a minimal test framework to ensure that they can be
refactored safely.